### PR TITLE
fix: main is the main branch, master is a deprecated term

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,7 +3,7 @@ name: CD
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   cd:


### PR DESCRIPTION
Signed-off-by: Tory Clasen <ToryClasen@Gmail.com>